### PR TITLE
Add zeroops-cloud.is-a.dev domain configuration

### DIFF
--- a/domains/zeroops-cloud.json
+++ b/domains/zeroops-cloud.json
@@ -1,0 +1,11 @@
+{
+  "name": "zeroops-cloud",
+  "description": "ZeroOps DevOps Landing Page",
+  "owner": {
+    "email": "sms9960515873@gmail.com"
+  },
+  "record": {
+    "type": "CNAME",
+    "value": "sainathmitalakar.github.io"
+  }
+}


### PR DESCRIPTION
zeroops-cloud-setup Requesting subdomain `zeroops-cloud.is-a.dev` for my GitHub Pages project: https://github.com/sainathmitalakar/ZeroOps-Landing-Page


<!--
YOU MUST FILL OUT THIS TEMPLATE ENTIRELY FOR YOUR PR TO BE ACCEPTED, NONE OF IT IS OPTIONAL UNLESS SPECIFIED.
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->

<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [ ] I have **read** and **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. -->
- [ ] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [ ] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied/mostly blank templated websites. -->
- [ ] My website is **software development** related. <!-- Only your root subdomain needs to meet this requirement. -->
- [ ] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. X/Twitter or Discord) for contact. -->
- [ ] I have provided a preview of my website below. <!-- This step is required for your domain to be approved. -->

# Website Preview
<!-- Provide a link or screenshot of your website below. -->
